### PR TITLE
Fix dockerfile to use arch instead of machine name

### DIFF
--- a/kiosk/Dockerfile.template
+++ b/kiosk/Dockerfile.template
@@ -1,1 +1,1 @@
-FROM bh.cr/balenablocks/browser-%%BALENA_MACHINE_NAME%%/2.4.2
+FROM bh.cr/balenablocks/browser-%%BALENA_ARCH%%/2.4.2


### PR DESCRIPTION
Change-type: minor
Signed-off-by: Anuj Deshpande <anuj@balena.io>